### PR TITLE
make xpath for PPN number more specific to avoid catching the PPN of containing work

### DIFF
--- a/qurator/tsvtools/ocrd_processors.py
+++ b/qurator/tsvtools/ocrd_processors.py
@@ -34,7 +34,7 @@ class OcrdNeatExportProcessor(Processor):
         iiif_url_template = self.parameter['iiif_url_template']
         noproxy = self.parameter['noproxy']
 
-        ppn_found = self.workspace.mets._tree.find('//mods:recordIdentifier[@source="gbv-ppn"]', NS)
+        ppn_found = self.workspace.mets._tree.find('//mods:mods/mods:recordInfo/mets:recordIdentifier[@source="gbv-ppn"]', NS)
         if ppn_found is not None:
             ppn = ppn_found.text
         else:


### PR DESCRIPTION
For example in PPN1757226095's mets.xml

```xml
<mods:relatedItem type="host">
            <mods:recordInfo>
              <mods:recordIdentifier source="gbv-ppn">PPN1757226095</mods:recordIdentifier>
            </mods:recordInfo>
          </mods:relatedItem>
          <mods:recordInfo>
            <mods:recordIdentifier source="gbv-ppn">PPN183049435X</mods:recordIdentifier>
          </mods:recordInfo>
```

the previous, greedy xpath would select the `PPN1757226095` instead of `PPN183049435X` which breaks the IIIF links.