### PR TITLE
.gitignore: Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 *.egg-info
 __pycache__
 tests/**/*.jpg


### PR DESCRIPTION
That directory is created by `make all` from ocrd_all and should be ignored to get a clean `git status`.