### PR TITLE
non-legacy namespace package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/qurator/__init__.py
+++ b/qurator/__init__.py
@@ -1,2 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)
-

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*",
                                     "tests.*", "tests"]),
     install_requires=install_requires,
-    namespace_packages=['qurator'],
     package_data={
         '': ['*.json']
     },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from io import open
 from json import load
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 with open('requirements.txt') as fp:
     install_requires = fp.read()
@@ -18,8 +18,7 @@ setup(
     keywords='qurator',
     license='Apache License 2.0',
     url="https://github.com/qurator-spk/neath",
-    packages=find_packages(exclude=["*.tests", "*.tests.*",
-                                    "tests.*", "tests"]),
+    packages=find_namespace_packages(include=['qurator']),
     install_requires=install_requires,
     package_data={
         '': ['*.json']


### PR DESCRIPTION
The current [legacy](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/) approach to namespace packaging does not work with development/editable installation. See https://github.com/OCR-D/ocrd_all/issues/433

This PR fixes it for this package – analogous PRs to the other `qurator` repos will follow.